### PR TITLE
Var to var references - reshape

### DIFF
--- a/binary-array-ld-cli/src/test/kotlin/net/bald/BinaryArrayConvertCliTest.kt
+++ b/binary-array-ld-cli/src/test/kotlin/net/bald/BinaryArrayConvertCliTest.kt
@@ -339,7 +339,7 @@ class BinaryArrayConvertCliTest {
      * Requirements class E-1, E-2
      */
     @Test
-    fun run_withVariableReferenceAttributes_outputsVariableReferences() {
+    fun run_withVariableValueAttributes_outputsVariableValues() {
         val inputFile = writeToNetCdf("/netcdf/var-ref.cdl")
         val outputFile = createTempFile()
         val contextFile = ResourceFileConverter.toFile("/jsonld/context.json")
@@ -393,9 +393,9 @@ class BinaryArrayConvertCliTest {
                             }
                         }
                         statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/foo/var1")) {
+                            statement(TestVocab.references, createPlainLiteral("var9"))
                             statement(TestVocab.siblingVar, createResource("http://test.binary-array-ld.net/example/foo/bar/var2"))
                             statement(RDF.type, BALD.Resource)
-                            statement(BALD.references, createPlainLiteral("var9"))
                         }
                     }
                     statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/var0")) {
@@ -420,39 +420,37 @@ class BinaryArrayConvertCliTest {
             outputFile.absolutePath
         )
 
-        fun sortAnon(res: Resource): String {
-            return if (res.hasProperty(BALD.target)) {
-                res.getProperty(BALD.target).`object`.toString()
-            } else {
-                res.id.toString()
-            }
-        }
-
         val model = createDefaultModel().read(outputFile.toURI().toString(), "ttl")
         ModelVerifier(model).apply {
             resource("http://test.binary-array-ld.net/example") {
                 statement(RDF.type, BALD.Container)
                 statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/")) {
                     statement(RDF.type, BALD.Container)
-                    statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/elev"), sortAnon = ::sortAnon) {
+                    statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/elev"), sortAnon = ::sortRefs) {
                         statement(RDF.type, BALD.Array)
                         statement(RDFS.label, createPlainLiteral("height"))
                         statement(BALD.references) {
                             statement(RDF.type, BALD.Reference)
+                            statement(BALD.sourceRefShape) {
+                                list(15, 10)
+                            }
                             statement(BALD.target, createResource("http://test.binary-array-ld.net/example/lat"))
                             statement(BALD.targetRefShape) {
-                                list(createTypedLiteral(15), createTypedLiteral(1))
+                                list(15, 1)
                             }
                         }
                         statement(BALD.references) {
                             statement(RDF.type, BALD.Reference)
+                            statement(BALD.sourceRefShape) {
+                                list(15, 10)
+                            }
                             statement(BALD.target, createResource("http://test.binary-array-ld.net/example/lon"))
                             statement(BALD.targetRefShape) {
-                                list(createTypedLiteral(1), createTypedLiteral(10))
+                                list(1, 10)
                             }
                         }
                         statement(BALD.shape) {
-                            list(createTypedLiteral(15), createTypedLiteral(10))
+                            list(15, 10)
                         }
                     }
                     statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/lat")) {
@@ -461,7 +459,7 @@ class BinaryArrayConvertCliTest {
                         statement(BALD.arrayFirstValue, createTypedLiteral("6.5", XSDDatatype.XSDfloat))
                         statement(BALD.arrayLastValue, createTypedLiteral("-6.5", XSDDatatype.XSDfloat))
                         statement(BALD.shape) {
-                            list(createTypedLiteral(15))
+                            list(15)
                         }
                     }
                     statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/lon")) {
@@ -470,11 +468,90 @@ class BinaryArrayConvertCliTest {
                         statement(BALD.arrayFirstValue, createTypedLiteral("0.5", XSDDatatype.XSDfloat))
                         statement(BALD.arrayLastValue, createTypedLiteral("9.5", XSDDatatype.XSDfloat))
                         statement(BALD.shape) {
-                            list(createTypedLiteral(10))
+                            list(10)
                         }
                     }
                 }
             }
+        }
+    }
+
+    @Test
+    fun run_withVariableReferences_outputsVariableReferences() {
+        val inputFile = writeToNetCdf("/netcdf/ref-attr.cdl")
+        val outputFile = createTempFile()
+
+        run(
+            "--uri", "http://test.binary-array-ld.net/example",
+            inputFile.absolutePath,
+            outputFile.absolutePath
+        )
+
+        val model = createDefaultModel().read(outputFile.toURI().toString(), "ttl")
+        ModelVerifier(model).apply {
+            resource("http://test.binary-array-ld.net/example") {
+                statement(RDF.type, BALD.Container)
+                statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/")) {
+                    statement(RDF.type, BALD.Container)
+                    statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/var0"), sortAnon = ::sortRefs) {
+                        statement(RDF.type, BALD.Array)
+                        statement(BALD.references) {
+                            statement(RDF.type, BALD.Reference)
+                            statement(BALD.sourceRefShape) {
+                                list(10, 90, 15, 1)
+                            }
+                            statement(BALD.target, createResource("http://test.binary-array-ld.net/example/var1"))
+                            statement(BALD.targetRefShape) {
+                                list(1, 90, 15, 60)
+                            }
+                        }
+                        statement(BALD.references) {
+                            statement(RDF.type, BALD.Reference)
+                            statement(BALD.sourceRefShape) {
+                                list(10, 90, 15)
+                            }
+                            statement(BALD.target, createResource("http://test.binary-array-ld.net/example/var2"))
+                            statement(BALD.targetRefShape) {
+                                list(1, 1, 15)
+                            }
+                        }
+                        statement(BALD.shape) {
+                            list(10, 90, 15)
+                        }
+                    }
+                    statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/var1")) {
+                        statement(RDF.type, BALD.Array)
+                        statement(BALD.references) {
+                            statement(RDF.type, BALD.Reference)
+                            statement(BALD.sourceRefShape) {
+                                list(90, 15, 60)
+                            }
+                            statement(BALD.target, createResource("http://test.binary-array-ld.net/example/var2"))
+                            statement(BALD.targetRefShape) {
+                                list(1, 15, 1)
+                            }
+                        }
+                        statement(BALD.shape) {
+                            list(90, 15, 60)
+                        }
+                    }
+                    statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/var2")) {
+                        statement(RDF.type, BALD.Array)
+                        statement(BALD.shape) {
+                            list(15)
+                        }
+                    }
+                    statement(BALD.isPrefixedBy, createPlainLiteral("prefix_list"))
+                }
+            }
+        }
+    }
+
+    private fun sortRefs(res: Resource): String {
+        return if (res.hasProperty(BALD.target)) {
+            res.getProperty(BALD.target).`object`.toString()
+        } else {
+            res.id.toString()
         }
     }
 }

--- a/binary-array-ld-cli/src/test/kotlin/net/bald/BinaryArrayConvertCliTest.kt
+++ b/binary-array-ld-cli/src/test/kotlin/net/bald/BinaryArrayConvertCliTest.kt
@@ -480,9 +480,11 @@ class BinaryArrayConvertCliTest {
     fun run_withVariableReferences_outputsVariableReferences() {
         val inputFile = writeToNetCdf("/netcdf/ref-attr.cdl")
         val outputFile = createTempFile()
+        val aliasFile = ResourceFileConverter.toFile("/turtle/var-alias.ttl", "ttl")
 
         run(
             "--uri", "http://test.binary-array-ld.net/example",
+            "--alias", aliasFile.absolutePath,
             inputFile.absolutePath,
             outputFile.absolutePath
         )
@@ -520,6 +522,7 @@ class BinaryArrayConvertCliTest {
                         }
                     }
                     statement(BALD.contains, createResource("http://test.binary-array-ld.net/example/var1")) {
+                        statement(TestVocab.references, createResource("http://test.binary-array-ld.net/example/var2"))
                         statement(RDF.type, BALD.Array)
                         statement(BALD.references) {
                             statement(RDF.type, BALD.Reference)

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/Attribute.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/Attribute.kt
@@ -14,5 +14,5 @@ interface Attribute {
     /**
      * The values of the attribute, expressed as RDF resource or literal nodes.
      */
-    val values: List<RDFNode>
+    val values: Sequence<RDFNode>
 }

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/AttributeSource.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/AttributeSource.kt
@@ -8,5 +8,5 @@ interface AttributeSource {
      * Obtain the list of attributes that describe this entity.
      * @return The list of attributes.
      */
-    fun attributes(): List<Attribute>
+    fun attributes(): Sequence<Attribute>
 }

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/Dimension.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/Dimension.kt
@@ -5,13 +5,12 @@ package net.bald
  */
 interface Dimension {
     /**
+     * The uniquely identifying name of the dimension in the binary array.
+     */
+    val name: String
+
+    /**
      * The size of the dimension.
      */
     val size: Int
-
-    /**
-     * The coordinate variable that corresponds to the dimension, if one exists.
-     * Otherwise, null.
-     */
-    val coordinate: Var?
 }

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/Var.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/Var.kt
@@ -18,4 +18,9 @@ interface Var: AttributeSource {
      * The dimensions that specify the shape of the variable.
      */
     fun dimensions(): Sequence<Dimension>
+
+    /**
+     * The other variables which the variable references.
+     */
+    fun references(): Sequence<Var>
 }

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelBinaryArrayConverter.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelBinaryArrayConverter.kt
@@ -11,7 +11,8 @@ import org.apache.jena.shared.PrefixMapping
 object ModelBinaryArrayConverter {
     private val modelFct = run {
         val attrFct = ModelAttributeBuilder.Factory()
-        val varFct = ModelVarBuilder.Factory(attrFct)
+        val refFct = ModelReferenceBuilder.Factory()
+        val varFct = ModelVarBuilder.Factory(attrFct, refFct)
         val containerFct = ModelContainerBuilder.Factory(varFct, attrFct)
         ModelBinaryArrayBuilder.Factory(containerFct)
     }

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelReferenceBuilder.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelReferenceBuilder.kt
@@ -1,0 +1,57 @@
+package net.bald.model
+
+import net.bald.Dimension
+import net.bald.Var
+import net.bald.vocab.BALD
+import org.apache.jena.rdf.model.Literal
+import org.apache.jena.rdf.model.Resource
+import org.apache.jena.rdf.model.ResourceFactory
+import org.apache.jena.vocabulary.RDF
+
+class ModelReferenceBuilder(
+    v: Var,
+    private val vRes: Resource
+) {
+    private val sourceShape = Shape(v)
+    private val model = vRes.model
+
+    fun addReference(target: Var) {
+        val targetShape = Shape(target)
+        val dimIds = (sourceShape.dims + targetShape.dims).map(Dimension::name).distinct()
+        val sourceRefShape = sourceShape.shape(dimIds).let(model::createList)
+        val targetRefShape = targetShape.shape(dimIds).let(model::createList)
+        val targetRes = target.uri.let(model::createResource)
+
+        val reference = model.createResource()
+            .addProperty(RDF.type, BALD.Reference)
+            .addProperty(BALD.sourceRefShape, sourceRefShape)
+            .addProperty(BALD.targetRefShape, targetRefShape)
+            .addProperty(BALD.target, targetRes)
+
+        vRes.addProperty(BALD.references, reference)
+    }
+
+    class Shape(
+        val dims: List<Dimension>
+    ) {
+        constructor(v: Var): this(v.dimensions().toList())
+
+        private val dimsById = dims.associateBy(Dimension::name)
+
+        fun shape(dimIds: List<String>): Iterator<Literal> {
+            return dimIds.asSequence().map { dimId ->
+                dimsById[dimId]?.size?.let(ResourceFactory::createTypedLiteral) ?: unitNode
+            }.iterator()
+        }
+    }
+
+    companion object {
+        private val unitNode = ResourceFactory.createTypedLiteral(1)
+    }
+
+    open class Factory {
+        open fun forVar(v: Var, vRes: Resource): ModelReferenceBuilder {
+            return ModelReferenceBuilder(v, vRes)
+        }
+    }
+}

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelVarBuilder.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelVarBuilder.kt
@@ -24,7 +24,9 @@ open class ModelVarBuilder(
 
     private fun addAttributes(source: AttributeSource, resource: Resource) {
         val builder = attrFct.forResource(resource)
-        source.attributes().forEach(builder::addAttribute)
+        source.attributes().filterNot { attr ->
+            BALD.references.hasURI(attr.uri)
+        }.forEach(builder::addAttribute)
     }
 
     private fun addCoordinateRange(v: Var, resource: Resource) {

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelVarBuilder.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/model/ModelVarBuilder.kt
@@ -4,16 +4,13 @@ import net.bald.AttributeSource
 import net.bald.Dimension
 import net.bald.Var
 import net.bald.vocab.BALD
-import org.apache.jena.rdf.model.Model
-import org.apache.jena.rdf.model.RDFList
-import org.apache.jena.rdf.model.RDFNode
-import org.apache.jena.rdf.model.Resource
+import org.apache.jena.rdf.model.*
 import org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral
-import org.apache.jena.vocabulary.RDF
 
 open class ModelVarBuilder(
     private val container: Resource,
-    private val attrFct: ModelAttributeBuilder.Factory
+    private val attrFct: ModelAttributeBuilder.Factory,
+    private val refFct: ModelReferenceBuilder.Factory
 ) {
     open fun addVar(v: Var) {
         val dimBuilder = dimensionBuilder(v)
@@ -21,7 +18,8 @@ open class ModelVarBuilder(
         container.addProperty(BALD.contains, vRes)
         addAttributes(v, vRes)
         addCoordinateRange(v, vRes)
-        dimBuilder.addDimensions(vRes)
+        dimBuilder.addShape(vRes)
+        dimBuilder.addReferences(vRes)
     }
 
     private fun addAttributes(source: AttributeSource, resource: Resource) {
@@ -43,81 +41,57 @@ open class ModelVarBuilder(
     private fun dimensionBuilder(v: Var): VarDimensionBuilder {
         val dims = v.dimensions().toList()
         return if (dims.isEmpty()) {
-            VarDimensionBuilder.Base
+            VarDimensionBuilder.BaldResource
         } else {
-            VarDimensionBuilder.Dimensional(container.model, dims)
+            BaldArray(v, dims)
         }
     }
 
     private interface VarDimensionBuilder {
         val type: Resource
-        fun addDimensions(resource: Resource)
+        fun addShape(resource: Resource)
+        fun addReferences(resource: Resource)
 
-        object Base: VarDimensionBuilder {
+        object BaldResource: VarDimensionBuilder {
             override val type: Resource get() = BALD.Resource
 
-            override fun addDimensions(resource: Resource) {
+            override fun addShape(resource: Resource) {
+                // do nothing
+            }
+
+            override fun addReferences(resource: Resource) {
                 // do nothing
             }
         }
+    }
 
-        class Dimensional(
-            private val model: Model,
-            private val dims: List<Dimension>
-        ): VarDimensionBuilder {
-            override val type: Resource get() = BALD.Array
+    private inner class BaldArray(
+        private val v: Var,
+        private val dims: List<Dimension>,
+    ): VarDimensionBuilder {
+        override val type: Resource get() = BALD.Array
 
-            override fun addDimensions(resource: Resource) {
-                val model = resource.model
-                val shape = shape()
-                resource.addProperty(BALD.shape, shape)
+        override fun addShape(resource: Resource) {
+            val shape = dims.map(::size).iterator().let(resource.model::createList)
+            resource.addProperty(BALD.shape, shape)
+        }
 
-                dims.forEachIndexed { idx, dim ->
-                    dim.coordinate?.let { coordinate ->
-                        if (coordinate.uri != resource.uri) {
-                            val target = model.createResource(coordinate.uri)
-                            val targetRefShape = targetRefShape(dim, idx)
+        private fun size(dim: Dimension): RDFNode {
+            return createTypedLiteral(dim.size)
+        }
 
-                            val reference = model.createResource()
-                                .addProperty(RDF.type, BALD.Reference)
-                                .addProperty(BALD.targetRefShape, targetRefShape)
-                                .addProperty(BALD.target, target)
-                            resource.addProperty(BALD.references, reference)
-                        }
-                    }
-                }
-            }
-
-            private fun shape(): RDFList {
-                val sizeIt = dims.map(::size).iterator()
-                return model.createList(sizeIt)
-            }
-
-            private fun targetRefShape(dim: Dimension, ordinal: Int): RDFList {
-                val nodeIt = (dims.indices).map { idx ->
-                    if (idx == ordinal) {
-                        size(dim)
-                    } else unitNode
-                }.iterator()
-
-                return model.createList(nodeIt)
-            }
-
-            private fun size(dim: Dimension): RDFNode {
-                return createTypedLiteral(dim.size)
-            }
+        override fun addReferences(resource: Resource) {
+            val builder = refFct.forVar(v, resource)
+            v.references().forEach(builder::addReference)
         }
     }
 
-    companion object {
-        private val unitNode = createTypedLiteral(1)
-    }
-
     open class Factory(
-        private val attrFct: ModelAttributeBuilder.Factory
+        private val attrFct: ModelAttributeBuilder.Factory,
+        private val refFct: ModelReferenceBuilder.Factory
     ) {
         open fun forContainer(container: Resource): ModelVarBuilder {
-            return ModelVarBuilder(container, attrFct)
+            return ModelVarBuilder(container, attrFct, refFct)
         }
     }
 }

--- a/binary-array-ld-lib/src/main/kotlin/net/bald/vocab/BALD.kt
+++ b/binary-array-ld-lib/src/main/kotlin/net/bald/vocab/BALD.kt
@@ -28,6 +28,7 @@ object BALD {
     val isPrefixedBy: Property = createProperty("${prefix}isPrefixedBy")
     val references: Property = createProperty("${prefix}references")
     val shape: Property = createProperty("${prefix}shape")
+    val sourceRefShape: Property = createProperty("${prefix}sourceRefShape")
     val targetRefShape: Property = createProperty("${prefix}targetRefShape")
     val arrayFirstValue: Property = createProperty("${prefix}arrayFirstValue")
     val arrayLastValue: Property = createProperty("${prefix}arrayLastValue")

--- a/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelAttributeBuilderTest.kt
+++ b/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelAttributeBuilderTest.kt
@@ -22,7 +22,7 @@ class ModelAttributeBuilderTest {
     @Test
     fun addAttribute_withoutValues_doesNothing() {
         attr.stub {
-            on { values } doReturn emptyList()
+            on { values } doReturn emptySequence()
         }
         builder.addAttribute(attr)
         ResourceVerifier(resource).statements {
@@ -34,7 +34,7 @@ class ModelAttributeBuilderTest {
     fun addAttribute_singleValue_addsStatement() {
         val value = createPlainLiteral("Variable 0")
         attr.stub {
-            on { values } doReturn listOf(value)
+            on { values } doReturn sequenceOf(value)
         }
         builder.addAttribute(attr)
         ResourceVerifier(resource).statements {
@@ -49,7 +49,7 @@ class ModelAttributeBuilderTest {
             createPlainLiteral("Variable 0")
         )
         attr.stub {
-            on { this.values } doReturn values
+            on { this.values } doReturn values.asSequence()
         }
         builder.addAttribute(attr)
         ResourceVerifier(resource).statements {
@@ -62,7 +62,7 @@ class ModelAttributeBuilderTest {
     fun addAttribute_resourceValue_addsStatement() {
         val value = createResource("http://test.binary-array-ld.net/label")
         attr.stub {
-            on { values } doReturn listOf(value)
+            on { values } doReturn sequenceOf(value)
         }
         builder.addAttribute(attr)
         ResourceVerifier(resource).statements {
@@ -78,7 +78,7 @@ class ModelAttributeBuilderTest {
             createResource("http://test.binary-array-ld.net/var2")
         )
         attr.stub {
-            on { values } doReturn listOf(value)
+            on { values } doReturn sequenceOf(value)
         }
         builder.addAttribute(attr)
         ResourceVerifier(resource).statements {

--- a/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelBinaryArrayConverterTest.kt
+++ b/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelBinaryArrayConverterTest.kt
@@ -27,6 +27,8 @@ class ModelBinaryArrayConverterTest {
         return mock {
             on { this.uri } doReturn uri
             on { dimensions() } doReturn emptySequence()
+            on { attributes() } doReturn emptySequence()
+            on { references() } doReturn emptySequence()
         }
     }
 
@@ -38,6 +40,7 @@ class ModelBinaryArrayConverterTest {
             on { this.uri } doReturn "$uri/"
             on { vars() } doReturn vars.asSequence()
             on { subContainers() } doReturn emptySequence()
+            on { attributes() } doReturn emptySequence()
         }
         val prefix = PrefixMapping.Factory.create()
             .setNsPrefix("bald", BALD.prefix)

--- a/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelContainerBuilderTest.kt
+++ b/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelContainerBuilderTest.kt
@@ -31,7 +31,7 @@ class ModelContainerBuilderTest {
     private val container = mock<Container> {
         on { uri } doReturn "http://test.binary-array-ld.net/example/foo"
         on { vars() } doReturn vars.asSequence()
-        on { attributes() } doReturn attrs
+        on { attributes() } doReturn attrs.asSequence()
         on { subContainers() } doReturn emptySequence()
     }
 

--- a/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelReferenceBuilderTest.kt
+++ b/binary-array-ld-lib/src/test/kotlin/net/bald/model/ModelReferenceBuilderTest.kt
@@ -1,0 +1,149 @@
+package net.bald.model
+
+import bald.model.ResourceVerifier
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import net.bald.Dimension
+import net.bald.Var
+import net.bald.vocab.BALD
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.rdf.model.ResourceFactory.createResource
+import org.apache.jena.vocabulary.RDF
+import org.junit.jupiter.api.Test
+
+class ModelReferenceBuilderTest {
+    private val sourceDims = listOf(
+        newDimension("dim1", 10),
+        newDimension("dim2", 90),
+        newDimension("dim3", 15)
+    )
+    private val v = mock<Var> {
+        on { dimensions() } doReturn sourceDims.asSequence()
+    }
+    private val model = ModelFactory.createDefaultModel()
+    private val vRes = model.createResource("http://test.binary-array-ld.net/example")
+    private val builder = ModelReferenceBuilder.Factory().forVar(v, vRes)
+
+    private fun newVar(uri: String, dims: List<Dimension>): Var {
+        return mock {
+            on { this.uri } doReturn uri
+            on { this.dimensions() } doReturn dims.asSequence()
+        }
+    }
+
+    private fun newDimension(name: String, size: Int): Dimension {
+        return mock {
+            on { this.name } doReturn name
+            on { this.size } doReturn size
+        }
+    }
+
+    @Test
+    fun addReference_coordinateVar() {
+        val coordinate = newVar("http://test.binary-array-ld.net/example/foo", listOf(sourceDims[1]))
+        builder.addReference(coordinate)
+
+        ResourceVerifier(vRes).statements {
+            statement(BALD.references) {
+                statement(RDF.type, BALD.Reference)
+                statement(BALD.sourceRefShape) {
+                    list(10, 90, 15)
+                }
+                statement(BALD.target, createResource("http://test.binary-array-ld.net/example/foo"))
+                statement(BALD.targetRefShape) {
+                    list(1, 90, 1)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun addReference_lowerDimensionVar() {
+        val coordinate = newVar("http://test.binary-array-ld.net/example/foo", sourceDims.subList(0, 2))
+        builder.addReference(coordinate)
+
+        ResourceVerifier(vRes).statements {
+            statement(BALD.references) {
+                statement(RDF.type, BALD.Reference)
+                statement(BALD.sourceRefShape) {
+                    list(10, 90, 15)
+                }
+                statement(BALD.target, createResource("http://test.binary-array-ld.net/example/foo"))
+                statement(BALD.targetRefShape) {
+                    list(10, 90, 1)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun addReference_higherDimensionVar() {
+        val higherDims = listOf(
+            newDimension("dim4", 10),
+            newDimension("dim5", 60)
+        )
+        val coordinate = newVar("http://test.binary-array-ld.net/example/foo", sourceDims + higherDims)
+        builder.addReference(coordinate)
+
+        ResourceVerifier(vRes).statements {
+            statement(BALD.references) {
+                statement(RDF.type, BALD.Reference)
+                statement(BALD.sourceRefShape) {
+                    list(10, 90, 15, 1, 1)
+                }
+                statement(BALD.target, createResource("http://test.binary-array-ld.net/example/foo"))
+                statement(BALD.targetRefShape) {
+                    list(10, 90, 15, 10, 60)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun addReference_disjointDimensionVar() {
+        val targetDims = listOf(
+            newDimension("dim4", 10),
+            newDimension("dim5", 60)
+        )
+        val coordinate = newVar("http://test.binary-array-ld.net/example/foo", targetDims)
+        builder.addReference(coordinate)
+
+        ResourceVerifier(vRes).statements {
+            statement(BALD.references) {
+                statement(RDF.type, BALD.Reference)
+                statement(BALD.sourceRefShape) {
+                    list(10, 90, 15, 1, 1)
+                }
+                statement(BALD.target, createResource("http://test.binary-array-ld.net/example/foo"))
+                statement(BALD.targetRefShape) {
+                    list(1, 1, 1, 10, 60)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun addReference_partiallyDisjointDimensionVar() {
+        val targetDims = listOf(
+            sourceDims[1],
+            sourceDims[2],
+            newDimension("dim4", 10),
+            newDimension("dim5", 60)
+        )
+        val coordinate = newVar("http://test.binary-array-ld.net/example/foo", targetDims)
+        builder.addReference(coordinate)
+
+        ResourceVerifier(vRes).statements {
+            statement(BALD.references) {
+                statement(RDF.type, BALD.Reference)
+                statement(BALD.sourceRefShape) {
+                    list(10, 90, 15, 1, 1)
+                }
+                statement(BALD.target, createResource("http://test.binary-array-ld.net/example/foo"))
+                statement(BALD.targetRefShape) {
+                    list(1, 90, 15, 10, 60)
+                }
+            }
+        }
+    }
+}

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfAttribute.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfAttribute.kt
@@ -16,8 +16,8 @@ class NetCdfAttribute(
 
     override val uri: String get() = prop.uri
 
-    override val values: List<RDFNode> get() {
-        return rawValues()?.flatMap(::nodes)?.toList() ?: emptyList()
+    override val values: Sequence<RDFNode> get() {
+        return rawValues()?.flatMap(::nodes) ?: emptySequence()
     }
 
     fun rawValues(): Sequence<String>? {

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfAttribute.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfAttribute.kt
@@ -20,7 +20,7 @@ class NetCdfAttribute(
         return rawValues()?.flatMap(::nodes)?.toList() ?: emptyList()
     }
 
-    private fun rawValues(): Sequence<String>? {
+    fun rawValues(): Sequence<String>? {
         return if (attr.isArray) {
             attr.values?.let { values ->
                 ArrayIterator(values).asSequence().map(Any::toString)

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfAttributeSource.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfAttributeSource.kt
@@ -12,10 +12,10 @@ class NetCdfAttributeSource(
     private val attrs: AttributeContainer
 ): AttributeSource {
 
-    override fun attributes(): List<net.bald.Attribute> {
+    override fun attributes(): Sequence<NetCdfAttribute> {
         return attrs.asSequence().filterNot(::isReserved).map { attr ->
             NetCdfAttribute(parent, attr)
-        }.toList()
+        }
     }
 
     private fun isReserved(attr: Attribute): Boolean {

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfContainer.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfContainer.kt
@@ -55,7 +55,7 @@ abstract class NetCdfContainer(
         return true
     }
 
-    override fun attributes(): List<Attribute> {
+    override fun attributes(): Sequence<Attribute> {
         return group.attributes().let(::source).attributes()
     }
 
@@ -81,9 +81,13 @@ abstract class NetCdfContainer(
         return uriParser.parse(value)?.let(::createResource)?.let(::listOf)
             ?: alias.resource(value)?.let(::listOf)
             ?: prop.takeIf(alias::isReferenceProperty)?.let {
-                refParser.parse(value)
+                refParser.parse(value)?.asResources()
             }
             ?: createPlainLiteral(value).let(::listOf)
+    }
+
+    fun parseReferences(value: String): ReferenceCollection? {
+        return refParser.parse(value)
     }
 
     override fun toString(): String {

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfDimension.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfDimension.kt
@@ -1,20 +1,15 @@
 package net.bald.netcdf
 
-import net.bald.Var
 import ucar.nc2.Dimension
 
 /**
  * NetCDF implementation of [net.bald.Dimension].
  */
 class NetCdfDimension(
-    private val parent: NetCdfContainer,
     private val dim: Dimension
 ): net.bald.Dimension {
+    override val name: String get() = dim.fullName
     override val size: Int get() = dim.length
 
-    override val coordinate: Var? get() {
-        return parent.vars().find { v ->
-            v.isCoordinate() && v.name == dim.shortName
-        }
-    }
+    val shortName get() = dim.shortName
 }

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfVar.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfVar.kt
@@ -31,7 +31,6 @@ class NetCdfVar(
         return v.attributes()
             .let(::source)
             .attributes()
-            .filterNot(::isVarReference)
     }
 
     private fun source(attrs: AttributeContainer): NetCdfAttributeSource {
@@ -70,15 +69,10 @@ class NetCdfVar(
     private fun attributeRefs(): Sequence<NetCdfVar> {
         return v.attributes().let(::source)
             .attributes()
-            .filter(::isVarReference)
             .mapNotNull(NetCdfAttribute::rawValues)
             .flatten()
             .mapNotNull(parent::parseReferences)
             .flatMap(ReferenceCollection::asVars)
-    }
-
-    private fun isVarReference(attr: NetCdfAttribute): Boolean {
-        return BALD.references.hasURI(attr.uri)
     }
 
     override fun toString(): String {

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfVar.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/NetCdfVar.kt
@@ -1,9 +1,8 @@
 package net.bald.netcdf
 
-import net.bald.Attribute
 import net.bald.CoordinateRange
-import net.bald.Dimension
 import net.bald.Var
+import net.bald.vocab.BALD
 import ucar.nc2.AttributeContainer
 import ucar.nc2.Variable
 
@@ -14,8 +13,9 @@ class NetCdfVar(
     private val parent: NetCdfContainer,
     private val v: Variable
 ): Var {
-    val name: String get() = v.shortName
-    override val uri: String get() = parent.childUri(name)
+    val shortName: String get() = v.shortName
+    val name: String get() = v.fullName
+    override val uri: String get() = parent.childUri(shortName)
 
     fun isCoordinate(): Boolean {
         return v.isCoordinateVariable
@@ -27,20 +27,58 @@ class NetCdfVar(
         } else null
     }
 
-    override fun attributes(): List<Attribute> {
-        return v.attributes().let(::source).attributes()
+    override fun attributes(): Sequence<NetCdfAttribute> {
+        return v.attributes()
+            .let(::source)
+            .attributes()
+            .filterNot(::isVarReference)
     }
 
     private fun source(attrs: AttributeContainer): NetCdfAttributeSource {
         return NetCdfAttributeSource(parent, attrs)
     }
 
-    override fun dimensions(): Sequence<Dimension> {
+    override fun dimensions(): Sequence<NetCdfDimension> {
         return v.dimensions.asSequence().map(::dimension)
     }
 
-    private fun dimension(dim: ucar.nc2.Dimension): Dimension {
-        return NetCdfDimension(parent, dim)
+    private fun dimension(dim: ucar.nc2.Dimension): NetCdfDimension {
+        return NetCdfDimension(dim)
+    }
+
+    override fun references(): Sequence<Var> {
+        val coordinates = coordinateRefs()
+        val attrs = attributeRefs()
+
+        return (coordinates + attrs).distinctBy(NetCdfVar::uri)
+    }
+
+    private fun coordinateRefs(): Sequence<NetCdfVar> {
+        val dims = dimensions().toList()
+        return if (dims.isNotEmpty()) {
+            val coordinatesByName = parent.vars()
+                .filterNot { v -> v.name == name }
+                .filter(NetCdfVar::isCoordinate)
+                .associateBy { v -> v.shortName }
+
+            dims.asSequence()
+                .map(NetCdfDimension::shortName)
+                .mapNotNull(coordinatesByName::get)
+        } else emptySequence()
+    }
+
+    private fun attributeRefs(): Sequence<NetCdfVar> {
+        return v.attributes().let(::source)
+            .attributes()
+            .filter(::isVarReference)
+            .mapNotNull(NetCdfAttribute::rawValues)
+            .flatten()
+            .mapNotNull(parent::parseReferences)
+            .flatMap(ReferenceCollection::asVars)
+    }
+
+    private fun isVarReference(attr: NetCdfAttribute): Boolean {
+        return BALD.references.hasURI(attr.uri)
     }
 
     override fun toString(): String {

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/ReferenceCollection.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/ReferenceCollection.kt
@@ -1,0 +1,44 @@
+package net.bald.netcdf
+
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.rdf.model.Resource
+import org.apache.jena.rdf.model.ResourceFactory
+
+interface ReferenceCollection {
+    fun asVars(): Collection<NetCdfVar>
+    fun asResources(): List<Resource>
+
+    class Unordered(
+        private val vars: List<NetCdfVar>
+    ): ReferenceCollection {
+        override fun asVars(): Collection<NetCdfVar> {
+            return vars
+        }
+
+        override fun asResources(): List<Resource> {
+            return vars.asSequence()
+                .map(NetCdfVar::uri)
+                .map(ResourceFactory::createResource)
+                .toList()
+        }
+    }
+
+    class Ordered(
+        private val vars: List<NetCdfVar>
+    ): ReferenceCollection {
+        override fun asVars(): Collection<NetCdfVar> {
+            return vars
+        }
+
+        override fun asResources(): List<Resource> {
+            val nodeIt = vars.asSequence()
+                .map(NetCdfVar::uri)
+                .map(ResourceFactory::createResource)
+                .iterator()
+
+            return ModelFactory.createDefaultModel()
+                .createList(nodeIt)
+                .let(::listOf)
+        }
+    }
+}

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/ReferenceCollector.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/ReferenceCollector.kt
@@ -1,0 +1,22 @@
+package net.bald.netcdf
+
+interface ReferenceCollector {
+    val raw: String
+    fun collect(vars: List<NetCdfVar>): ReferenceCollection
+
+    class Unordered(
+        override val raw: String
+    ): ReferenceCollector {
+        override fun collect(vars: List<NetCdfVar>): ReferenceCollection {
+            return ReferenceCollection.Unordered(vars)
+        }
+    }
+
+    class Ordered(
+        override val raw: String
+    ): ReferenceCollector {
+        override fun collect(vars: List<NetCdfVar>): ReferenceCollection {
+            return ReferenceCollection.Ordered(vars)
+        }
+    }
+}

--- a/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/ReferenceValueParser.kt
+++ b/binary-array-ld-netcdf/src/main/kotlin/net/bald/netcdf/ReferenceValueParser.kt
@@ -1,17 +1,13 @@
 package net.bald.netcdf
 
-import org.apache.jena.rdf.model.ModelFactory
-import org.apache.jena.rdf.model.Resource
-import org.apache.jena.rdf.model.ResourceFactory
-
 class ReferenceValueParser(
     private val group: NetCdfContainer
 ) {
-    fun parse(value: String): List<Resource>? {
+    fun parse(value: String): ReferenceCollection? {
         return value.trim().let(::doParse)
     }
 
-    private fun doParse(value: String): List<Resource>? {
+    private fun doParse(value: String): ReferenceCollection? {
         val collector = if (value.startsWith('(') && value.endsWith(')')) {
             value.substringAfter('(').substringBeforeLast(')').let(ReferenceCollector::Ordered)
         } else {
@@ -32,30 +28,7 @@ class ReferenceValueParser(
             .map(String::trim)
     }
 
-    private fun resolve(value: String): Resource? {
-        return NetCdfPath.parse(value).locateVar(group)?.uri?.let(ResourceFactory::createResource)
-    }
-
-    private interface ReferenceCollector {
-        val raw: String
-        fun collect(nodes: List<Resource>): List<Resource>
-
-        class Unordered(
-            override val raw: String
-        ): ReferenceCollector {
-            override fun collect(nodes: List<Resource>): List<Resource> {
-                return nodes
-            }
-
-        }
-
-        class Ordered(
-            override val raw: String
-        ): ReferenceCollector {
-            override fun collect(nodes: List<Resource>): List<Resource> {
-                val nodeIt = nodes.iterator()
-                return ModelFactory.createDefaultModel().createList(nodeIt).let(::listOf)
-            }
-        }
+    private fun resolve(value: String): NetCdfVar? {
+        return NetCdfPath.parse(value).locateVar(group)
     }
 }

--- a/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/DimensionVerifier.kt
+++ b/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/DimensionVerifier.kt
@@ -17,12 +17,4 @@ class DimensionVerifier(
     fun size(size: Int) {
         assertEquals(size, dim.size)
     }
-
-    /**
-     * Verify that the dimension corresponds to the given coordinate variable.
-     * @param uri The URI of the expected coordinate variable.
-     */
-    fun coordinate(uri: String) {
-        assertEquals(uri, dim.coordinate?.uri)
-    }
 }

--- a/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/DimensionsVerifier.kt
+++ b/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/DimensionsVerifier.kt
@@ -1,14 +1,17 @@
 package net.bald.netcdf
 
 import net.bald.Dimension
+import kotlin.test.assertEquals
 import kotlin.test.fail
 
 class DimensionsVerifier(
     private val dimIt: Iterator<Dimension>
 ) {
-    fun dimension(verify: DimensionVerifier.() -> Unit) {
+    fun dimension(name: String, verify: DimensionVerifier.() -> Unit) {
         if (dimIt.hasNext()) {
-            dimIt.next().let(::DimensionVerifier).verify()
+            val dim = dimIt.next()
+            assertEquals(name, dim.name)
+            DimensionVerifier(dim).verify()
         } else {
             fail("Expected a dimension but no more were found.")
         }

--- a/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/NetCdfBinaryArrayTest.kt
+++ b/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/NetCdfBinaryArrayTest.kt
@@ -317,7 +317,7 @@ class NetCdfBinaryArrayTest {
                     vars {
                         variable("http://test.binary-array-ld.net/var-ref.nc/foo/var1") {
                             attributes {
-                                attribute(BALD.references.uri, createPlainLiteral("var9"))
+                                attribute(TestVocab.references.uri, createPlainLiteral("var9"))
                                 attribute(TestVocab.siblingVar.uri, createResource("http://test.binary-array-ld.net/var-ref.nc/foo/bar/var2"))
                             }
                         }
@@ -344,12 +344,16 @@ class NetCdfBinaryArrayTest {
         val ba = fromCdl("/netcdf/coordinate-var.cdl", "http://test.binary-array-ld.net/coordinate-var.nc")
         ContainerVerifier(ba.root).vars {
             variable("http://test.binary-array-ld.net/coordinate-var.nc/elev") {
+                references(
+                    "http://test.binary-array-ld.net/coordinate-var.nc/lat",
+                    "http://test.binary-array-ld.net/coordinate-var.nc/lon"
+                )
                 dimensions {
-                    dimension {
-                        size(15); coordinate("http://test.binary-array-ld.net/coordinate-var.nc/lat")
+                    dimension("lat") {
+                        size(15)
                     }
-                    dimension {
-                        size(10); coordinate("http://test.binary-array-ld.net/coordinate-var.nc/lon")
+                    dimension("lon") {
+                        size(10)
                     }
                 }
             }
@@ -360,6 +364,29 @@ class NetCdfBinaryArrayTest {
             variable("http://test.binary-array-ld.net/coordinate-var.nc/lon") {
                 dimensions(10)
                 range(0.5F, 9.5F)
+            }
+        }
+    }
+
+    @Test
+    fun vars_range_withReferenceAttributes_returnsReferences() {
+        val ba = fromCdl("/netcdf/ref-attr.cdl", "http://test.binary-array-ld.net/ref-attr.nc")
+        ContainerVerifier(ba.root).vars {
+            variable("http://test.binary-array-ld.net/ref-attr.nc/var0") {
+                dimensions(10, 90, 15)
+                references(
+                    "http://test.binary-array-ld.net/ref-attr.nc/var1",
+                    "http://test.binary-array-ld.net/ref-attr.nc/var2"
+                )
+            }
+            variable("http://test.binary-array-ld.net/ref-attr.nc/var1") {
+                dimensions(90, 15, 60)
+                references(
+                    "http://test.binary-array-ld.net/ref-attr.nc/var2"
+                )
+            }
+            variable("http://test.binary-array-ld.net/ref-attr.nc/var2") {
+                dimensions(15)
             }
         }
     }

--- a/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/NetCdfBinaryArrayTest.kt
+++ b/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/NetCdfBinaryArrayTest.kt
@@ -369,7 +369,7 @@ class NetCdfBinaryArrayTest {
     }
 
     @Test
-    fun vars_range_withReferenceAttributes_returnsReferences() {
+    fun vars_withReferenceAttributes_returnsReferences() {
         val ba = fromCdl("/netcdf/ref-attr.cdl", "http://test.binary-array-ld.net/ref-attr.nc")
         ContainerVerifier(ba.root).vars {
             variable("http://test.binary-array-ld.net/ref-attr.nc/var0") {

--- a/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/ReferenceValueParserTest.kt
+++ b/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/ReferenceValueParserTest.kt
@@ -19,7 +19,7 @@ class ReferenceValueParserTest {
 
     @Test
     fun singleValue_returnsResource() {
-        val results = parser.parse("var0")
+        val results = parser.parse("var0")?.asResources()
         assertNotNull(results) {
             assertEquals(1, it.size)
             assertEquals("$uri/var0", it.single().uri)
@@ -34,7 +34,7 @@ class ReferenceValueParserTest {
 
     @Test
     fun unorderedSet_returnsResources() {
-        val results = parser.parse("var0 var1 foo/var2")
+        val results = parser.parse("var0 var1 foo/var2")?.asResources()
         assertNotNull(results) {
             assertEquals(3, it.size)
             assertEquals("$uri/var0", it[0].uri)
@@ -45,7 +45,7 @@ class ReferenceValueParserTest {
 
     @Test
     fun unorderedSet_withExtraWhitespace_returnsResources() {
-        val results = parser.parse(" var0  var1   foo/var2  ")
+        val results = parser.parse(" var0  var1   foo/var2  ")?.asResources()
         assertNotNull(results) {
             assertEquals(3, it.size)
             assertEquals("$uri/var0", it[0].uri)
@@ -62,7 +62,7 @@ class ReferenceValueParserTest {
 
     @Test
     fun orderedList_returnsRdfList() {
-        val results = parser.parse("(var0 var1 foo/var2)")
+        val results = parser.parse("(var0 var1 foo/var2)")?.asResources()
         assertNotNull(results) {
             assertEquals(1, it.size)
             val list = it.single() as RDFList
@@ -75,7 +75,7 @@ class ReferenceValueParserTest {
 
     @Test
     fun orderedList_withExtraWhitespace_returnsRdfList() {
-        val results = parser.parse(" ( var0 var1  foo/var2 ) ")
+        val results = parser.parse(" ( var0 var1  foo/var2 ) ")?.asResources()
         assertNotNull(results) {
             assertEquals(1, it.size)
             val list = it.single() as RDFList

--- a/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/VarVerifier.kt
+++ b/binary-array-ld-netcdf/src/test/kotlin/net/bald/netcdf/VarVerifier.kt
@@ -46,4 +46,13 @@ class VarVerifier(
             assertEquals(last, range.last)
         }
     }
+
+    /**
+     * Verify that the variable has references to variables of the given URIs, in order.
+     * @param uris The expected URIs.
+     */
+    fun references(vararg uris: String) {
+        val actual = v.references().map(Var::uri).toList()
+        assertEquals(uris.toList(), actual)
+    }
 }

--- a/binary-array-ld-test/src/main/kotlin/bald/TestVocab.kt
+++ b/binary-array-ld-test/src/main/kotlin/bald/TestVocab.kt
@@ -12,6 +12,7 @@ object TestVocab {
     /**
      * Properties
      */
+    val references: Property = createProperty("${prefix}references")
     val rootVar: Property = createProperty("${prefix}root_var")
     val parentVar: Property = createProperty("${prefix}parent_var")
     val siblingVar: Property = createProperty("${prefix}sibling_var")

--- a/binary-array-ld-test/src/main/kotlin/bald/model/StatementsVerifier.kt
+++ b/binary-array-ld-test/src/main/kotlin/bald/model/StatementsVerifier.kt
@@ -1,6 +1,7 @@
 package bald.model
 
 import org.apache.jena.rdf.model.*
+import org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral
 import org.apache.jena.vocabulary.RDF
 import org.junit.jupiter.api.fail
 import kotlin.test.assertEquals
@@ -70,6 +71,10 @@ class StatementsVerifier(
 
     fun list(vararg values: RDFNode) {
         values.toList().let(::list)
+    }
+
+    fun list(vararg values: Int) {
+        values.map(::createTypedLiteral).let(::list)
     }
 
     fun list(values: List<RDFNode>) {

--- a/binary-array-ld-test/src/main/resources/netcdf/ref-attr.cdl
+++ b/binary-array-ld-test/src/main/resources/netcdf/ref-attr.cdl
@@ -8,12 +8,13 @@ netcdf attributes {
         int var0(d0, d1, d2) ;
             var0:bald__references = "var1 var2" ;
         int var1(d1, d2, d3) ;
-            var1:bald__references = "var2";
+            var1:test__references = "var2";
         int var2(d2) ;
 
     :bald__isPrefixedBy = "prefix_list";
 
     group: prefix_list {
         :bald__ = "https://www.opengis.net/def/binary-array-ld/";
+        :test__ = "http://test.binary-array-ld.net/vocab/";
     }
 }

--- a/binary-array-ld-test/src/main/resources/netcdf/ref-attr.cdl
+++ b/binary-array-ld-test/src/main/resources/netcdf/ref-attr.cdl
@@ -1,0 +1,19 @@
+netcdf attributes {
+    dimensions:
+        d0 = 10 ;
+        d1 = 90 ;
+        d2 = 15 ;
+        d3 = 60 ;
+    variables:
+        int var0(d0, d1, d2) ;
+            var0:bald__references = "var1 var2" ;
+        int var1(d1, d2, d3) ;
+            var1:bald__references = "var2";
+        int var2(d2) ;
+
+    :bald__isPrefixedBy = "prefix_list";
+
+    group: prefix_list {
+        :bald__ = "https://www.opengis.net/def/binary-array-ld/";
+    }
+}

--- a/binary-array-ld-test/src/main/resources/turtle/var-alias.ttl
+++ b/binary-array-ld-test/src/main/resources/turtle/var-alias.ttl
@@ -9,7 +9,7 @@
 skos:prefLabel a rdf:Property ;
     dct:identifier "prefLabel" .
 
-bald:references a owl:ObjectProperty ;
+test:references a owl:ObjectProperty ;
     dct:identifier "references" ;
     rdfs:range bald:Resource .
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+## Welcome to GitHub Pages
+
+You can use the [editor on GitHub](https://github.com/simonoakesepimorphics/net.binary_array_ld.bald/edit/master/docs/index.md) to maintain and preview the content for your website in Markdown files.
+
+Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
+
+### Markdown
+
+Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
+
+```markdown
+Syntax highlighted code block
+
+# Header 1
+## Header 2
+### Header 3
+
+- Bulleted
+- List
+
+1. Numbered
+2. List
+
+**Bold** and _Italic_ and `Code` text
+
+[Link](url) and ![Image](src)
+```
+
+For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
+
+### Jekyll Themes
+
+Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/simonoakesepimorphics/net.binary_array_ld.bald/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
+
+### Support or Contact
+
+Having trouble with Pages? Check out our [documentation](https://docs.github.com/categories/github-pages-basics/) or [contact support](https://support.github.com/contact) and we’ll help you sort it out.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.4.32</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <junit.version>4.12</junit.version>
         <junit.platform.version>1.2.0</junit.platform.version>


### PR DESCRIPTION
Fixes #31 
Implements the spec changes from https://github.com/opengeospatial/netcdf-ld/pull/76.

* Infer references from variable to variable relationships (`ModelReferenceBuilder`).
* Replaced `coordinate` property on  `Dimension` with generalised `references` list on `Var`.
* Changed some lists to sequences for optimisation.

