### PR TITLE
Fix untagged releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@
 name: GitHub tagged release
 on:
   push:
-    branches: [ "master" ]
     tags: [ "*" ]
 jobs:
   build:


### PR DESCRIPTION
Release workflow was triggering on pushes to master OR tagged commits.

Ideally it should be triggered only when there is a tag AND the branch is master, but after some research I can't find a way to configure this.
I have changed the workflow trigger to only **tags on any branch**, which is not ideal but is slightly less volatile.